### PR TITLE
fix cmake syntax for finding credentials.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(PICO_SDK_FETCH_FROM_GIT on)
 include(cmake/pico_sdk_import.cmake)
 
 
-if(EXISTS cmake/credentials.cmake)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/credentials.cmake)
     # copy it over from cmake/credentials.cmake.example
     include(cmake/credentials.cmake)
 else()


### PR DESCRIPTION
When building this project from another cmake project, I get an error even though I have credentials.cmake (this is on Debian Bookworm using cmake 3.25):

    CMake Warning at pico-w-webserver-example/CMakeLists.txt:24 (message):
      Credentials file not found, using default values!

Per the cmake docs, `if EXISTS` requires full/absolute paths; relative paths do not have well-defined behavior:

    <https://cmake.org/cmake/help/latest/command/if.html#exists>