### PR TITLE
Fix makefsdata URL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ set(MAKE_FS_DATA_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/external/makefsdata)
 
 if (NOT EXISTS ${MAKE_FS_DATA_SCRIPT})
         file(DOWNLOAD
-                https://raw.githubusercontent.com/krzmaz/lwip/e15654409d14a238aec5ed4bd5516063938c9345/src/apps/http/makefsdata/makefsdata
+                https://raw.githubusercontent.com/lwip-tcpip/lwip/e799c266facc3c70190676eccad49d6c2db2caac/src/apps/http/makefsdata/makefsdata
                 ${MAKE_FS_DATA_SCRIPT}
                 )
 endif()


### PR DESCRIPTION
The current URL points to a non-existing file: [https://raw.githubusercontent.com/krzmaz/lwip/e15654409d14a238aec5ed4bd5516063938c9345/src/apps/http/makefsdata/makefsdata](https://raw.githubusercontent.com/krzmaz/lwip/e15654409d14a238aec5ed4bd5516063938c9345/src/apps/http/makefsdata/makefsdata)

Thus the `src/external/makefsdata` file ends up being empty and no `src/fsdata.c` gets generated.
This results in the following error:

```
...
Running makefsdata script
CMake Error at src/CMakeLists.txt:18 (file):
  file RENAME failed to rename

    <path>/pico-w-webserver-example/src/fsdata.c

  to

    <path>/pico-w-webserver-example/src/my_fsdata.c

  because: No such file or directory



-- Configuring incomplete, errors occurred!
...
```
My change seems to result in a working build, but I basically just guessed an alternative.